### PR TITLE
adding initial infrastructure for gcp single tenant module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+#  Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# asdf tool-versions
+.tool-versions
+
+# generated dbt config files
+dbt_config.sh
+config.yaml
+
+.DS_Store

--- a/dbt_config.tf
+++ b/dbt_config.tf
@@ -1,0 +1,130 @@
+resource "local_file" "script" {
+  count    = var.create_admin_console_script ? 1 : 0
+  filename = "./dbt_config.sh"
+  content  = <<EOT
+gcloud container clusters get-credentials ${var.namespace}-${var.environment}-cluster --region ${var.region} --project ${data.google_project.project.name}
+kubectl config set-context --current --namespace=${var.existing_namespace ? var.custom_namespace : kubernetes_namespace.dbt_cloud.0.metadata.0.name}
+curl https://kots.io/install | bash
+kubectl kots install dbt-cloud-v1${var.release_channel} --namespace ${var.existing_namespace ? var.custom_namespace : kubernetes_namespace.dbt_cloud.0.metadata.0.name} --shared-password ${var.admin_console_password} --config-values ${local_file.config.0.filename}
+EOT
+}
+
+resource "local_file" "config" {
+  count    = var.create_admin_console_script ? 1 : 0
+  filename = "./config.yaml"
+  content  = <<EOT
+apiVersion: kots.io/v1beta1
+kind: ConfigValues
+metadata:
+  creationTimestamp: null
+  name: dbt-cloud
+spec:
+  values:
+    app_memory:
+      value: ${var.app_memory}
+    app_replicas:
+      value: "${var.app_replicas}"
+    artifacts_s3_bucket:
+      value: ${var.artifacts_s3_bucket}
+    aws_access_key_id:
+      value: ${var.aws_access_key_id}
+    aws_secret_access_key:
+      value: ${var.aws_secret_access_key}
+    azure_storage_connection_string: {}
+    database_dbname:
+      value: "${var.namespace}${var.environment}"
+    database_embedded_storage_gb:
+      value: "10"
+    database_hostname:
+      value: "${google_sql_database_instance.dbt_cloud_db_instance.private_ip_address}"
+    database_password:
+      value: "${google_sql_user.db_user.password}"
+    database_port:
+      value: "5432"
+    database_sslmode:
+      value: require
+    database_storage_class:
+      value: default
+    database_user:
+      value: "${google_sql_user.db_user.name}"
+    datadog_enabled:
+      value: "${var.datadog_enabled == true ? 1 : 0}"
+    db_type:
+      default: external
+      value: external
+    disable_anonymous_tracking:
+      value: "0"
+    django_debug_mode:
+      value: "0"
+    django_superuser_password:
+      value: ${var.superuser_password}
+    enable_okta:
+      value: "0"
+    encryption_method:
+      default: rsa
+      value: rsa
+    github_api_url: {}
+    github_app_client_id: {}
+    github_app_client_secret: {}
+    github_app_configure_url: {}
+    github_app_id: {}
+    github_app_install_url: {}
+    github_base_url: {}
+    github_enabled:
+      value: "0"
+    github_private_key_pem: {}
+    google_api_url:
+      value: https://www.googleapis.com
+    google_settings_type:
+      default: defaults
+    hostname:
+      value: ${var.domain_affix == "" ? var.environment : var.domain_affix}.${var.domain_name}
+    ide_storage_class:
+      value: ${var.ide_storage_class}
+    imageRegistry:
+      value: registry.replicated.com/dbt-cloud-v1/
+    kms_key_id:
+      value: ""
+    nginx_memory:
+      value: ${var.nginx_memory}
+    rsa_private_key:
+      value: "${tls_private_key.rsa_key.private_key_pem}"
+    rsa_public_key:
+      value: "${tls_private_key.rsa_key.public_key_pem}"
+    run_logs_s3_bucket:
+      value: ${var.logs_s3_bucket}
+    s3_endpoint_url:
+      value: https://s3.${var.region}.amazonaws.com
+    s3_region:
+      value: ${var.region}
+    saml_private_key: {}
+    saml_public_cert: {}
+    scaling_settings_type:
+      default: defaults
+    scheduler_memory:
+      value: ${var.scheduler_memory}
+    slack_enabled:
+      value: "0"
+    slack_key: {}
+    slack_secret: {}
+    smtp_auth_enabled:
+      value: "1"
+    smtp_enabled:
+      value: "0"
+    smtp_host:
+      value: ""
+    smtp_password:
+      value: ""
+    smtp_port:
+      value: "587"
+    smtp_tls_enabled:
+      value: "1"
+    smtp_username:
+      value: ""
+    storage_method:
+      default: s3
+    system_from_email_address:
+      value: ""
+status: {}
+EOT
+}

--- a/dns.tf
+++ b/dns.tf
@@ -1,0 +1,11 @@
+data "google_dns_managed_zone" "dns_zone" {
+  name = var.hosted_zone_name
+}
+
+resource "google_dns_record_set" "cname" {
+  name         = "${var.environment}.${var.domain_name}."
+  managed_zone = data.google_dns_managed_zone.dns_zone.name
+  type         = "CNAME"
+  ttl          = 60
+  rrdatas      = ["${var.environment}.${var.domain_name}."]
+}

--- a/examples/standard/main.tf
+++ b/examples/standard/main.tf
@@ -1,0 +1,26 @@
+provider "google" {
+  project = var.project_name
+  region  = var.region
+}
+
+module "single_tenant_staging" {
+
+  source = "../../"
+
+  namespace           = var.namespace
+  environment         = var.environment
+  region              = var.region
+  vpc_id              = google_compute_network.network.id
+  vpc_name            = google_compute_network.network.name
+  private_subnet_name = google_compute_subnetwork.private_subnet.name
+  k8s_node_count      = 2
+  k8s_node_type       = "e2-standard-2"
+  domain_name         = "singletenantgcp.getdbt.com"
+  hosted_zone_name    = "gcp-single-tenant"
+
+  # fill out with secure password before applying
+  db_password = ""
+
+  create_admin_console_script = true
+  
+}

--- a/examples/standard/variables.tf
+++ b/examples/standard/variables.tf
@@ -1,0 +1,12 @@
+variable "namespace" {
+  default = "singletenantgcp"
+}
+variable "environment" {
+  default = "standard"
+}
+variable "project_name" {
+  default = "gcp-dbt-cloud-single-tenant"
+}
+variable "region" {
+  default = "us-east1"
+}

--- a/examples/standard/vpc.tf
+++ b/examples/standard/vpc.tf
@@ -1,0 +1,24 @@
+resource "google_compute_network" "network" {
+  name = "${var.namespace}-${var.environment}-vpc"
+
+  auto_create_subnetworks = false
+  routing_mode            = "GLOBAL"
+}
+
+resource "google_compute_subnetwork" "private_subnet" {
+  name = "subnet-private-01"
+
+  ip_cidr_range = "10.194.0.0/20"
+  network       = google_compute_network.network.id
+  region        = var.region
+  secondary_ip_range = [
+    {
+      ip_cidr_range = "10.194.16.0/20"
+      range_name    = "pods"
+    },
+    {
+      ip_cidr_range = "10.194.32.0/20"
+      range_name    = "services"
+    },
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,119 @@
+provider "kubernetes" {
+  host                   = module.kubernetes_cluster.endpoint
+  cluster_ca_certificate = base64decode(module.kubernetes_cluster.ca_certificate)
+  token                  = data.google_client_config.provider.access_token
+  load_config_file       = false
+}
+
+module "kubernetes_cluster" {
+  source  = "terraform-google-modules/kubernetes-engine/google"
+  version = "12.2.0"
+
+  name              = "${var.namespace}-${var.environment}-cluster"
+  network           = var.vpc_name
+  project_id        = data.google_project.project.name
+  region            = var.region
+  release_channel   = "STABLE"
+  subnetwork        = var.private_subnet_name
+  ip_range_pods     = var.ip_range_pods_name
+  ip_range_services = var.ip_range_services_name
+
+  regional = true
+
+  horizontal_pod_autoscaling = false
+
+  node_pools = [
+    {
+      name               = "default-node-pool"
+      machine_type       = var.k8s_node_type
+      node_locations     = var.k8s_node_count > 2 ? "${element(local.zones, 0)},${element(local.zones, 1)},${element(local.zones, 2)}" : "${element(local.zones, 0)},${element(local.zones, 1)}"
+      initial_node_count = var.k8s_node_count > 2 ? floor(var.k8s_node_count / 3) : 1
+      min_count          = var.k8s_node_count > 2 ? floor(var.k8s_node_count / 3) : 1
+      max_count          = var.k8s_node_count > 2 ? ceil(var.k8s_node_count / 3) : 1
+      disk_size_gb       = 100
+
+    },
+  ]
+}
+
+resource "kubernetes_namespace" "dbt_cloud" {
+  count = var.existing_namespace ? 0 : 1
+  metadata {
+    name = var.custom_namespace == "" ? "dbt-cloud-${var.namespace}-${var.environment}" : var.custom_namespace
+  }
+}
+
+resource "random_id" "db_name_suffix" {
+  byte_length = 4
+}
+
+resource "google_sql_database_instance" "dbt_cloud_db_instance" {
+  name             = "${var.namespace}${var.environment}${random_id.db_name_suffix.hex}"
+  database_version = "POSTGRES_12"
+
+  region = var.region
+
+  depends_on = [google_service_networking_connection.private_vpc_connection]
+
+  settings {
+    tier      = "db-f1-micro"
+    disk_size = 10
+
+    ip_configuration {
+      ipv4_enabled    = false
+      private_network = var.vpc_id
+      require_ssl     = false
+    }
+  }
+}
+
+resource "google_sql_database" "dbt_cloud_db" {
+  name     = "${var.namespace}${var.environment}"
+  instance = google_sql_database_instance.dbt_cloud_db_instance.name
+}
+
+resource "google_sql_user" "db_user" {
+  instance = google_sql_database_instance.dbt_cloud_db_instance.name
+  name     = "${var.namespace}${var.environment}"
+  password = var.db_password
+}
+
+resource "google_sql_ssl_cert" "db_cert" {
+  common_name = "${var.namespace}-${var.environment}-sql-cert"
+  instance    = google_sql_database_instance.dbt_cloud_db_instance.name
+}
+
+resource "google_compute_global_address" "private_ip_address" {
+  name          = "private-ip-address"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = var.vpc_id
+}
+
+resource "google_service_networking_connection" "private_vpc_connection" {
+  network                 = var.vpc_id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_ip_address.name]
+}
+
+resource "google_compute_global_address" "static_ip" {
+  name = "dbt-cloud-ip"
+}
+
+resource "tls_private_key" "rsa_key" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+data "google_project" "project" {}
+
+data "google_client_config" "provider" {}
+
+data "google_compute_zones" "zones" {
+  region = var.region
+}
+
+locals {
+  zones = data.google_compute_zones.zones.names
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,141 @@
+#required
+variable "namespace" {
+  type        = string
+  description = "Used as an identifier for various infrastructure components within the module. Usually single word that or the name of the organization. For exmaple: 'fishtownanalytics'"
+}
+variable "environment" {
+  type        = string
+  description = "The name of the environment for the deployment. For example: 'dev', 'prod', 'uat', 'standard', 'etc'"
+}
+variable "region" {
+  type        = string
+  description = "The region where the infrastructure is hosted."
+}
+variable "vpc_id" {
+  type        = string
+  description = "The ID of the VPC where the infrastructure is deployed."
+}
+variable "vpc_name" {
+  type        = string
+  description = "The name of the VPC where the infrastructure is deployed."
+}
+variable "private_subnet_name" {
+  type        = string
+  description = "The name of the private subnet where the GKE cluster is deployed."
+}
+variable "domain_name" {
+  type        = string
+  description = "The base URL of the dbt Cloud instance. This is generally affixed to the `environment` variable."
+}
+variable "hosted_zone_name" {
+  type        = string
+  description = "The name of the hosted zone where the corresponding DNS record lives."
+}
+variable "k8s_node_count" {
+  type        = number
+  description = "The number of Kubernetes nodes that will be created for the GKE worker group. Generally 2 nodes are recommended but it is recommended that you reach out to Fishtown Analytics to complete the capacity planning exercise prior to setting this."
+}
+variable "k8s_node_type" {
+  type        = string
+  description = "The GCP instance type of the Kubernetes nodes that will be created for the GKE node pool. It is recommended that you reach out to Fishtown Analytics to complete the capacity planning exercise prior to setting this."
+}
+variable "db_password" {
+  type        = string
+  description = "Password for RDS database. It is highly recommended that a secure password be generated and stored in a vault."
+}
+
+#optional
+variable "ip_range_pods_name" {
+  type        = string
+  default     = "pods"
+  description = "The name of the secondary IP range in the private subnet to be assigned to pods. This should be changed if the range is named something other than `pods` in the network setup."
+}
+variable "ip_range_services_name" {
+  type        = string
+  default     = "services"
+  description = "The name of the secondary IP range in the private subnet to be assigned to services. This should be changed if the range is named something other than `services` in the network setup."
+}
+variable "custom_namespace" {
+  type        = string
+  default     = ""
+  description = "If set this variable will create a custom K8s namespace for dbt Cloud. If not set the created namespace defaults to `dbt-cloud-<namespace>-<environment>`."
+}
+variable "existing_namespace" {
+  type        = bool
+  default     = false
+  description = "If set to `true`this will install dbt Cloud components into an existing namespace denoted by the `custom_namespace` field. This is not recommended as it is preferred to install dbt Cloud into a dedicated namespace."
+}
+variable "create_admin_console_script" {
+  type        = bool
+  default     = false
+  description = "If set to true will generate a script to automatically spin up the KOTS admin console with desired values and outputs from the module. The relevant variables below are suffixed with 'Admin Console Script' in their descriptions. These variables can also be left blank and manually entered into the script after applying if desired."
+}
+variable "aws_access_key_id" {
+  type        = string
+  default     = "<ENTER_AWS_ACCESS_KEY>"
+  description = "Admin Console Script - The AWS access key for an IAM identity with admin access that will be used for encryption. This is added to the config that is automatically uploaded to the KOTS admin console via the script."
+}
+variable "aws_secret_access_key" {
+  type        = string
+  default     = "<ENTER_AWS_SECRET_KEY>"
+  description = "Admin Console Script - The AWS secret key for an IAM identity with admin access that will be used for encryption. This is added to the config that is automatically uploaded to the KOTS admin console via the script."
+}
+variable "admin_console_password" {
+  type        = string
+  default     = "<ENTER_ADMIN_CONSOLE_PASSWORD>"
+  description = "Admin Console Script - The desired password for the KOTS admin console. This is added to the script and used when spinning the admin console."
+}
+variable "superuser_password" {
+  type        = string
+  default     = "<ENTER_SUPER_USER_PASSWORD>"
+  description = "Admin Console Script - The superuser password for the dbt Cloud application. This is added to the config that is automatically uploaded to the KOTS admin console via the script."
+}
+variable "datadog_enabled" {
+  type        = bool
+  default     = false
+  description = "If set to `true` this will enable dbt Cloud to send metrics to Datadog. Note that this requires the installation of a Datadog Agent in the K8s cluster where dbt Cloud is deployed."
+}
+variable "domain_affix" {
+  type        = string
+  default     = ""
+  description = "The affix of the URL, affixed to the `domain_name` variable, that the dbt Cloud deployment will resolve to. If left blank the affix will default to the value of the `environment` variable."
+}
+variable "release_channel" {
+  type        = string
+  default     = ""
+  description = "Admin Console Script - The license channel for customer deployment. This should be left unset unless instructed by Fishtown Analytics."
+}
+variable "app_memory" {
+  type        = string
+  default     = "1Gi"
+  description = "Admin Console Script - The memory dedicated to the application pods for dbt Cloud. This is added to the config that is automatically uploaded to the KOTS admin console via the script. This value should never be set to less than default. It is recommended that you reach out to Fishtown Analytics to complete the capacity planning exercise prior to modifying this."
+}
+variable "app_replicas" {
+  type        = number
+  default     = 2
+  description = "Admin Console Script - The number of application pods for dbt Cloud. This is added to the config that is automatically uploaded to the KOTS admin console via the script. This value should never be set to less than default. It is recommended that you reach out to Fishtown Analytics to complete the capacity planning exercise prior to modifying this."
+}
+variable "nginx_memory" {
+  type        = string
+  default     = "512Mi"
+  description = "Admin Console Script - The amount of memory dedicated to nginx for dbt Cloud. This is added to the config that is automatically uploaded to the KOTS admin console via the script. This value should never be set to less than default. It is recommended that you reach out to Fishtown Analytics to complete the capacity planning exercise prior to modifying this."
+}
+variable "scheduler_memory" {
+  type        = string
+  default     = "512Mi"
+  description = "Admin Console Script - The amount of memory dedicated to the scheduler for dbt Cloud. This is added to the config that is automatically uploaded to the KOTS admin console via the script. This value should never be set to less than default. It is recommended that you reach out to Fishtown Analytics to complete the capacity planning exercise prior to modifying this."
+}
+variable "ide_storage_class" {
+  type        = string
+  default     = "standard"
+  description = "Admin Console Script - The EFS provisioner storage class name used for the IDE. Only change if creating a custom EFS provisioner."
+}
+
+variable "artifacts_s3_bucket" {
+  type    = string
+  default = ""
+}
+variable "logs_s3_bucket" {
+  type    = string
+  default = ""
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 0.13.0"
+  required_providers {
+    google = {
+      version = "3.51.0"
+    }
+  }
+}


### PR DESCRIPTION
This PR contains the initial infrastructure for the GCP dbt Cloud Single Tenant module including the K8s cluster, SQL database, dbt install script generator, and other supporting infrastructure. With this module you can spin up the infrastructure, install dbt Cloud and access the instance using the KOTS port forwarding. Next steps are listed below.

Next steps:
- Get GCP ingress working
- Set up NFS provisioner 
- Set up GCP block storage (using S3 API)
- Troubleshoot apply/destroy issues that require multiple applies/destroys

[gcp-single-tenant-init-tf-plan.txt](https://github.com/fishtown-analytics/terraform-google-dbt-cloud-single-tenant/files/5756399/gcp-single-tenant-init-tf-plan.txt)
